### PR TITLE
Remove numpy deprecate module import

### DIFF
--- a/cad_to_shapely/cadimporter.py
+++ b/cad_to_shapely/cadimporter.py
@@ -5,7 +5,6 @@
 import abc
 import logging
 from typing import List,Tuple
-from numpy import deprecate
 
 import shapely.geometry as sg
 from shapely import ops


### PR DESCRIPTION
Gday @aegis1980! 

I'm trying to support `numpy` version 2 in `sectionproperties`, however it seems that the `deprecate` module you are importing in `cadimporter.py` no longer exists in `numpy>=2`. It doesn't look like this module is being used so I was hoping the import could be removed and a new release of `cad-to-shapely` generated to allow `numpy` 2 to work with `sectionproperties`.

Cheers,
Robbie